### PR TITLE
uses Q:type base64image for the image

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -93,7 +93,9 @@
             "type": "object",
             "properties": {
               "base64": {
-                "type": "string"
+                "title": "Bild auswählen",
+                "type": "string",
+                "Q:type": "base64image"
               },
               "altText": {
                 "title": "Alternativer Text",


### PR DESCRIPTION
Makes it look like this in Q Editor
<img width="614" alt="screen shot 2017-02-07 at 23 03 09" src="https://cloud.githubusercontent.com/assets/821875/22713650/ab57ff2a-ed89-11e6-8cda-a3a4569f689c.png">
