### PR TITLE
Removed alt text from schema and use candidate name instead

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -96,10 +96,6 @@
                 "title": "Bild auswählen",
                 "type": "string",
                 "Q:type": "base64image"
-              },
-              "altText": {
-                "title": "Alternativer Text",
-                "type": "string"
               }
             }
           }

--- a/views/Candidates.html
+++ b/views/Candidates.html
@@ -2,7 +2,7 @@
   <div class="q-election-executive-item">
     <div class="q-election-executive-item-image">
       {{#if candidate.image && candidate.image.base64}}
-        <img class="{{candidate.imageClassAttribute}}" src="{{candidate.image.base64}}" alt="{{candidate.image.altText}}"/>
+        <img class="{{candidate.imageClassAttribute}}" src="{{candidate.image.base64}}" alt="{{candidate.name}}"/>
       {{/if}}
     </div>
     <div class="q-election-executive-item-text">


### PR DESCRIPTION
As proposed in basecamp (https://3.basecamp.com/3500782/buckets/1333491/todos/380939690). Imho it's a good idea to just use the candidates name. What do you think? Is there a reason why we should not do it like that?