### PR TITLE
Remove majority line for others group & new version 2.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-elections-executive",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-elections-executive",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Q executive election tool",
   "keywords": [
     "storytelling",

--- a/views/Candidate.html
+++ b/views/Candidate.html
@@ -49,7 +49,7 @@
       <div class="q-election-executive-item-bar s-color-gray-3">
         <div class="q-election-executive-item-bar-color {{candidate.colorClass}}" style="{{candidate.colorStyle}} width: {{candidate.width}};"></div>
       </div>
-      {{#if !isLastCandidate && majority}}
+      {{#if !isLastCandidate && majority && !isOthers}}
       <div class="q-election-executive-majority s-color-gray-5" style="left: calc({{(majority * 100 / base).toFixed(2)}}% - 1px);">
       </div>
       {{/if}} {{#if isLastCandidate && majority}}


### PR DESCRIPTION
Fixes that a majority line is drawn for "others" group which should not be done. Deployed on staging