### PR TITLE
Release 3.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Q Election Executive [![Build Status](https://travis-ci.com/nzzdev/Q-election-executive.svg?branch=dev)](https://travis-ci.com/nzzdev/Q-election-executive) [![Greenkeeper badge](https://badges.greenkeeper.io/nzzdev/Q-election-executive.svg)](https://greenkeeper.io/)
 
-**Maintainer**: [benib](https://github.com/benib)
+**Maintainer**: [philipkueng](https://github.com/philipkueng)
 
 Q election executive is one tool of the Q toolbox to display results of executive elections. Test it in the [demo](https://editor.q.tools/).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-elections-executive",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Q executive election tool",
   "keywords": [
     "storytelling",

--- a/views/HtmlStatic.svelte
+++ b/views/HtmlStatic.svelte
@@ -188,7 +188,7 @@
 
     // process the group of other candidates differently - not part of the majority
     let othersIndex = sortedCandidates.findIndex(candidate => {
-      let othersPattern = /((.*(A|a)ndere\s.*)|(.*(S|s)onstig.*))/;
+      let othersPattern = /((.*(A|a)ndere$)|(.*Andere(r)?\s.*)|(.*(S|s)onstig.*))/;
       return othersPattern.test(candidate.name);
     });
     if (othersIndex >= 0) {


### PR DESCRIPTION
* Hotfix for handling of "others" candidates. Now "other candidates" have to be called "Andere" oder "Andere Kandidatin", "Anderer Kandidat" etc. but a candidate whose name is e.g. "Anderegg" will not be included in "others" list
* Just a hotfix, maybe that handling needs some rethinking/rebuilding work
* deployed on prod as hotfix with release branch not actual release